### PR TITLE
Run build-ci on push to gtracers branch, not main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - gtracers
 jobs:
   pre-ci:
     name: Pre-CI


### PR DESCRIPTION
One small mistake from the [recent PR to add build-CI](#5)